### PR TITLE
Add missing docstrings to functions in sup folder

### DIFF
--- a/sup/avg1dmode.py
+++ b/sup/avg1dmode.py
@@ -113,6 +113,23 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and plot marker for a given bin.
+
+        The determination is based on the bin's z-value, which indicates
+        whether the bin is empty or if its corresponding data point is
+        above or below the average y value for its x-bin.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: A tuple `(ccode, marker)` containing the color code (int)
+                and marker string for the bin.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/avg2dmode.py
+++ b/sup/avg2dmode.py
@@ -128,6 +128,25 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and plot marker for a given bin.
+
+        This function calculates the normalized z-value (average value)
+        for the bin and uses this to select an appropriate color code from
+        `ccs.ccodes` based on `color_z_lims`. The marker is always
+        `ms.regular_marker`.
+
+        This function relies on `bins_info`, `z_min`, `z_max`,
+        `color_z_lims`, `ccs` (CCodeSettings), and `ms` (MarkerSettings)
+        from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: A tuple `(ccode, marker)` containing the color code (int)
+                and marker string for the bin.
+        """
 
         z_val = bins_info[xiyi][2]
         z_norm = 0.0

--- a/sup/colormapsmode.py
+++ b/sup/colormapsmode.py
@@ -3,6 +3,20 @@ from sup.utils import prettify
 from sup.colors import cmaps
 
 def run(args):
+    """Prints a list of available colormaps to the console.
+
+    Each colormap is displayed as a series of colored blocks, using the
+    `prettify` function from `sup.utils` and the `cmaps` list from
+    `sup.colors`. The colormaps are indexed and presented with their
+    corresponding number.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments.
+            This function does not currently use any arguments from `args`.
+
+    Returns:
+        None
+    """
 
     print("Available colormaps")
     print("-------------------")

--- a/sup/colorsmode.py
+++ b/sup/colorsmode.py
@@ -2,6 +2,20 @@
 from sup.utils import prettify
 
 def run(args):
+    """Prints a table of all 256 available terminal colors to the console.
+
+    Each color is displayed as a block with its corresponding color code.
+    The `prettify` function from `sup.utils` is used for formatting
+    each color block, showing the color code itself on a background of
+    that color. The colors are arranged in a grid.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments.
+            This function does not currently use any arguments from `args`.
+
+    Returns:
+        None
+    """
 
     print("Available colors")
     print("----------------")

--- a/sup/graph1dmode.py
+++ b/sup/graph1dmode.py
@@ -102,6 +102,24 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a plot bin.
+
+        The determination is based on the bin's `z_val` (obtained from
+        `bins_info`), which indicates if the bin is empty (0), or if the
+        graph line passes through the lower half (1) or upper half (2)
+        of the bin.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: A tuple `(ccode, marker)` where `ccode` is the color
+                code (int) and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/graph2dmode.py
+++ b/sup/graph2dmode.py
@@ -120,6 +120,26 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a plot bin.
+
+        The function value f(x,y) for the bin center (`z_val`, obtained
+        from `bins_info`) is used to select a color from `ccs.ccodes`.
+        The selection is based on where `z_val` falls within the
+        intervals defined by `color_z_lims`. The marker is always
+        `ms.regular_marker`.
+
+        This function relies on `bins_info`, `color_z_lims`,
+        `ccs` (CCodeSettings), and `ms` (MarkerSettings) from the
+        outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: A tuple `(ccode, marker)` where `ccode` is the color
+                code (int) and `marker` is `ms.regular_marker`.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/hist1dmode.py
+++ b/sup/hist1dmode.py
@@ -157,6 +157,26 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a histogram bin.
+
+        The `z_val` from `bins_info` indicates if the bin is empty (0),
+        part of the histogram bar top (1 for lower half, 2 for upper
+        half of the bin), or part of the filled area below the bar top (-1).
+        This value is used to select the appropriate color code from `ccs`
+        and marker string from `ms`.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is the string for the plot marker (e.g.,
+                empty, bar top, or fill).
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/hist2dmode.py
+++ b/sup/hist2dmode.py
@@ -187,6 +187,25 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a 2D histogram bin.
+
+        It normalizes the bin's `z_val` (content/height from `bins_info`)
+        using `z_min` and `z_max`. The normalized value is then used with
+        `color_z_lims` to select a color from `ccs.ccodes`. The marker
+        is always `ms.regular_marker`.
+
+        This function relies on `bins_info`, `z_min`, `z_max`,
+        `color_z_lims`, `ccs` (CCodeSettings), and `ms` (MarkerSettings)
+        from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is `ms.regular_marker`.
+        """
 
         z_val = bins_info[xiyi][2]
         z_norm = 0.0

--- a/sup/maxmin1dmode.py
+++ b/sup/maxmin1dmode.py
@@ -15,9 +15,35 @@ from sup.markersettings import MarkerSettings
 
 
 def run_max(args):
+    """Calls the main 'run' function to plot maximum y-values per x-bin.
+
+    This is a wrapper function that calls the main `run` function of
+    `maxmin1dmode` with the mode explicitly set to "max". It's used to
+    generate a 1D graph of the maximum y-value for each x-bin.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments,
+            which are passed through to the main `run` function.
+
+    Returns:
+        None
+    """
     run(args, "max")
 
 def run_min(args):
+    """Calls the main 'run' function to plot minimum y-values per x-bin.
+
+    This is a wrapper function that calls the main `run` function of
+    `maxmin1dmode` with the mode explicitly set to "min". It's used to
+    generate a 1D graph of the minimum y-value for each x-bin.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments,
+            which are passed through to the main `run` function.
+
+    Returns:
+        None
+    """
     run(args, "min")
 
 def run(args, mode):
@@ -144,6 +170,25 @@ def run(args, mode):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a plot bin.
+
+        The determination is based on the bin's `z_val` (obtained from
+        `bins_info`). This value indicates if the bin is empty (0),
+        or if the line representing the max/min y-value for the
+        corresponding x-bin passes through the lower half (1) or
+        upper half (2) of this y-bin.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: A tuple `(ccode, marker)` where `ccode` is the color
+                code (int) and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/maxmin2dmode.py
+++ b/sup/maxmin2dmode.py
@@ -16,9 +16,35 @@ from sup.markersettings import MarkerSettings
 
 
 def run_max(args):
+    """Calls the main 'run' function to plot maximum z-values per (x,y)-bin.
+
+    This is a wrapper function that calls the main `run` function of
+    `maxmin2dmode` with the mode explicitly set to "max". It's used to
+    generate a 2D map of the maximum z-value for each (x,y)-bin.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments,
+            which are passed through to the main `run` function.
+
+    Returns:
+        None
+    """
     run(args, "max")
 
 def run_min(args):
+    """Calls the main 'run' function to plot minimum z-values per (x,y)-bin.
+
+    This is a wrapper function that calls the main `run` function of
+    `maxmin2dmode` with the mode explicitly set to "min". It's used to
+    generate a 2D map of the minimum z-value for each (x,y)-bin.
+
+    Args:
+        args (argparse.Namespace): The parsed command-line arguments,
+            which are passed through to the main `run` function.
+
+    Returns:
+        None
+    """
     run(args, "min")
 
 def run(args, mode):
@@ -164,6 +190,29 @@ def run(args, mode):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a 2D plot bin.
+
+        It normalizes the bin's `z_val` (selected max/min value from
+        `bins_info`) using `z_min` and `z_max`. This normalized value,
+        along with `color_z_lims`, selects a color from `ccs.ccodes`.
+        If the point corresponds to the overall maximum (when `s_type`
+        is "max") or minimum (when `s_type` is "min") s-value, and
+        `highlight_maxmin_point` is True, it uses a special marker
+        (`ms.special_marker`) and color (`ccs.max_bin_ccode`). Otherwise,
+        it uses `ms.regular_marker`.
+
+        This function relies on `bins_info`, `z_min`, `z_max`, `s_type`,
+        `highlight_maxmin_point`, `color_z_lims`, `ccs` (CCodeSettings),
+        and `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
         z_norm = 0.0

--- a/sup/plr1dmode.py
+++ b/sup/plr1dmode.py
@@ -158,6 +158,24 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a plot bin.
+
+        The determination is based on the bin's `z_val` (obtained from
+        `bins_info`). `z_val` indicates if the bin is empty (0), or if
+        the profile likelihood ratio line passes through the lower half (1)
+        or upper half (2) of the bin.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/plr2dmode.py
+++ b/sup/plr2dmode.py
@@ -152,6 +152,29 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a 2D PLR plot bin.
+
+        The `z_val` (likelihood ratio from `bins_info`) is used with
+        `color_z_lims` (derived from confidence levels) to select a
+        color from `ccs.ccodes`. If `z_val` is 1.0 (best-fit point),
+        and `use_capped_loglike` is False and `highlight_maxlike_point`
+        is True, it uses `ccs.max_bin_ccode` and `ms.special_marker`.
+        Otherwise, it uses `ms.regular_marker` and the color determined
+        by `color_z_lims`.
+
+        This function relies on `bins_info`, `color_z_lims`,
+        `use_capped_loglike`, `highlight_maxlike_point`,
+        `ccs` (CCodeSettings), and `ms` (MarkerSettings) from the
+        outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
         z_norm = z_val

--- a/sup/post1dmode.py
+++ b/sup/post1dmode.py
@@ -164,6 +164,25 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a 1D posterior bin.
+
+        The `z_val` from `bins_info` indicates if the bin is empty (0),
+        part of the histogram bar top (1 for lower half, 2 for upper
+        half of the bin), or part of the filled area below the bar top (-1).
+        This value is used to select the appropriate color code from `ccs`
+        and marker string from `ms`.
+
+        This function relies on `bins_info`, `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is the string for the plot marker.
+        """
 
         z_val = bins_info[xiyi][2]
 

--- a/sup/post2dmode.py
+++ b/sup/post2dmode.py
@@ -202,6 +202,24 @@ def run(args):
     # Define a function that returns the color code and marker for any bin 
     # coordinate xiyi in the plot
     def get_ccode_and_marker(xiyi):
+        """Determines the color code and marker for a 2D posterior bin.
+
+        The `z_val` from `bins_info` is the index of the credible region
+        the bin belongs to. This index is used directly to select a color
+        from `ccs.ccodes`. The marker is always `ms.regular_marker`.
+
+        This function relies on `bins_info`, `z_min`, `z_max` (which define
+        the range of credible region indices), `ccs` (CCodeSettings), and
+        `ms` (MarkerSettings) from the outer scope.
+
+        Args:
+            xiyi (tuple): The (x_bin_index, y_bin_index) coordinates
+                of the bin.
+
+        Returns:
+            tuple: `(ccode, marker)` where `ccode` is the color code (int)
+                and `marker` is `ms.regular_marker`.
+        """
 
         z_val = bins_info[xiyi][2]
         z_norm = 0.0

--- a/sup/utils.py
+++ b/sup/utils.py
@@ -524,6 +524,26 @@ def get_dataset_names_hdf5(hdf5_file_object):
     import h5py
     result = []
     def get_datasets(name, obj):
+        """Callback function for h5py.File.visititems to find datasets.
+
+        This function is designed to be used as a callable for the
+        `visititems` method of an `h5py.File` object. It checks if the
+        visited HDF5 item `obj` is a dataset. If it is, the item's
+        `name` is appended to the `result` list, which is defined in
+        the enclosing scope of `get_dataset_names_hdf5`.
+
+        This function relies on the `result` list from the outer scope
+        and the `h5py` library.
+
+        Args:
+            name (str): The name of the HDF5 item being visited.
+            obj (h5py.HLObject): The HDF5 item object itself.
+                Expected to be an instance of `h5py._hl.dataset.Dataset`
+                if it's a dataset.
+
+        Returns:
+            None: This function modifies the `result` list in place.
+        """
         if type(obj) is h5py._hl.dataset.Dataset:
             result.append(name)
 


### PR DESCRIPTION
This commit adds docstrings to various functions across the `sup` package that were previously missing them. This includes:
- `run` functions in `colorsmode.py` and `colormapsmode.py`.
- `run_max` and `run_min` wrapper functions in `maxmin1dmode.py` and `maxmin2dmode.py`.
- Inner `get_ccode_and_marker` functions in `avg1dmode.py`, `avg2dmode.py`, `graph1dmode.py`, `graph2dmode.py`, `hist1dmode.py`, `hist2dmode.py`, `maxmin1dmode.py`, `maxmin2dmode.py`, `plr1dmode.py`, `plr2dmode.py`, `post1dmode.py`, and `post2dmode.py`.
- Inner `get_datasets` function in `utils.py`.

The added docstrings describe the purpose, arguments, and return values (where applicable) of these functions to improve code readability and maintainability.